### PR TITLE
SDK-2600 Removed xhprof from the requirements.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
         "spryker/testify": "*"
     },
     "suggest": {
+        "ext-xhprof": "If you want to use profiler module.",
         "spryker/container": "If you want to use Web Profiler plugins.",
-        "spryker/event-dispatcher": "If you want to use profiler listeners.",
-        "ext-xhprof": "If you want to use profiler module."
+        "spryker/event-dispatcher": "If you want to use profiler listeners."
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "suggest": {
         "spryker/container": "If you want to use Web Profiler plugins.",
         "spryker/event-dispatcher": "If you want to use profiler listeners.",
-        "ext-xhprof": "If you want tot use modules profiler tool graph."
+        "ext-xhprof": "If you want to use profiler module."
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,6 @@
     "description": "Profiler module",
     "license": "proprietary",
     "require": {
-        "ext-xhprof": "*",
         "php": ">=8.0",
         "spryker/event-dispatcher-extension": "^1.0.0",
         "spryker/kernel": "^3.30.0",
@@ -19,7 +18,8 @@
     },
     "suggest": {
         "spryker/container": "If you want to use Web Profiler plugins.",
-        "spryker/event-dispatcher": "If you want to use profiler listeners."
+        "spryker/event-dispatcher": "If you want to use profiler listeners.",
+        "ext-xhprof": "If you want tot use modules profiler tool graph."
     },
     "autoload": {
         "psr-4": {

--- a/src/Spryker/Shared/Profiler/ProfilerGraphDumper/SvgProfilerGraphDumper.php
+++ b/src/Spryker/Shared/Profiler/ProfilerGraphDumper/SvgProfilerGraphDumper.php
@@ -154,11 +154,13 @@ class SvgProfilerGraphDumper implements ProfilerGraphDumperInterface
     protected function createProfilerDataTransfer(string $svgData): ProfilerDataTransfer
     {
         $profilerDataStats = [static::STATS_MODULES_CALLS => count($this->processedNodes)];
+        $isXhprofExtensionEnabled = extension_loaded('xhprof');
 
         return (new ProfilerDataTransfer())
             ->setContent($svgData)
             ->setStats($profilerDataStats)
-            ->setType(static::SVG_DATA_TYPE);
+            ->setType(static::SVG_DATA_TYPE)
+            ->setIsXhprofExtensionEnabled($isXhprofExtensionEnabled);
     }
 
     /**

--- a/src/Spryker/Shared/Profiler/Transfer/profiler.transfer.xml
+++ b/src/Spryker/Shared/Profiler/Transfer/profiler.transfer.xml
@@ -5,6 +5,7 @@
         <property name="content" type="string"/>
         <property name="stats" type="array" singular="statsItem"/>
         <property name="type" type="string"/>
+        <property name="isXhprofExtensionEnabled" type="bool"/>
     </transfer>
 
 </transfers>

--- a/src/Spryker/Yves/Profiler/Theme/default/profiler.html.twig
+++ b/src/Spryker/Yves/Profiler/Theme/default/profiler.html.twig
@@ -8,14 +8,16 @@
         <span class="sf-toolbar-value">Profiler</span>
     {% endset %}
 
-    {% set text %}
-        <div class="sf-toolbar-info-piece">
-            {% for key, value in collector.profilerData.stats %}
-                <b>{{ key }}</b>
-                <span>{{ value }}</span>
-            {% endfor %}
-        </div>
-    {% endset %}
+    {% if collector.profilerData.isXhprofExtensionEnabled %}
+        {% set text %}
+            <div class="sf-toolbar-info-piece">
+                {% for key, value in collector.profilerData.stats %}
+                    <b>{{ key }}</b>
+                    <span>{{ value }}</span>
+                {% endfor %}
+            </div>
+        {% endset %}
+    {% endif %}
 
     {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: profiler_url, name: 'profiler'}) }}
 {% endblock %}
@@ -30,10 +32,13 @@
 {% endblock %}
 
 {% block panel %}
-    <a href="#" class="btn js-profiler-svg-graph-button">Download Trace Graph</a>
-    <div class="js-profiler-svg-graph" style="overflow: auto; margin-top: 10px">
-        {{ collector.profilerData.content | raw }}
-    </div>
-
-    {{ include('@Profiler/profiler-script.html.twig') }}
+    {% if collector.profilerData.isXhprofExtensionEnabled %}
+        <a href="#" class="btn js-profiler-svg-graph-button">Download Trace Graph</a>
+        <div class="js-profiler-svg-graph" style="overflow: auto; margin-top: 10px">
+            {{ collector.profilerData.content | raw }}
+        </div>
+        {{ include('@Profiler/profiler-script.html.twig') }}
+    {% else %}
+        <p>To view modules call trace please enable xhprof extension. See <a href="https://docs.spryker.com/docs/scos/dev/technical-enhancement-integration-guides/Integrate-profiler-module.html#prerequisites">profiler module docs.</a></p>
+    {% endif %}
 {% endblock %}

--- a/src/Spryker/Zed/Profiler/Presentation/profiler.html.twig
+++ b/src/Spryker/Zed/Profiler/Presentation/profiler.html.twig
@@ -8,14 +8,16 @@
         <span class="sf-toolbar-value">Profiler</span>
     {% endset %}
 
-    {% set text %}
-        <div class="sf-toolbar-info-piece">
-            {% for key, value in collector.profilerData.stats %}
-                <b>{{ key }}</b>
-                <span>{{ value }}</span>
-            {% endfor %}
-        </div>
-    {% endset %}
+    {% if collector.profilerData.isXhprofExtensionEnabled %}
+        {% set text %}
+            <div class="sf-toolbar-info-piece">
+                {% for key, value in collector.profilerData.stats %}
+                    <b>{{ key }}</b>
+                    <span>{{ value }}</span>
+                {% endfor %}
+            </div>
+        {% endset %}
+    {% endif %}
 
     {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: profiler_url, name: 'profiler'}) }}
 {% endblock %}
@@ -30,10 +32,14 @@
 {% endblock %}
 
 {% block panel %}
-    <a href="#" class="btn js-profiler-svg-graph-button">Download Trace Graph</a>
-    <div class="js-profiler-svg-graph" style="overflow: auto; margin-top: 10px">
-        {{ collector.profilerData.content | raw }}
-    </div>
+    {% if collector.profilerData.isXhprofExtensionEnabled %}
+        <a href="#" class="btn js-profiler-svg-graph-button">Download Trace Graph</a>
+        <div class="js-profiler-svg-graph" style="overflow: auto; margin-top: 10px">
+            {{ collector.profilerData.content | raw }}
+        </div>
 
-    {{ include('@Profiler/profiler-script.html.twig') }}
+        {{ include('@Profiler/profiler-script.html.twig') }}
+    {% else %}
+        <p>To view modules call trace please enable xhprof extension. See <a href="https://docs.spryker.com/docs/scos/dev/technical-enhancement-integration-guides/Integrate-profiler-module.html#prerequisites">profiler module docs.</a></p>
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
- Developer(s): @sergeyspryker

- Ticket: https://spryker.atlassian.net/browse/SDK-2600

- Docs PR: ACADEMY_URL_HERE

- Release Group: https://release.spryker.com/release-groups/view/4885

- merge: squash

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Profiler              | patch (currently 0.x)  |                       |

-----------------------------------------

#### Module Profiler

##### Change log

Adjustments

- Removed `ext-xhprof` from composer dependencies.
- Adjusted module templates to display profiler page with disabled `xhprof` extension.