### PR TITLE
FRW-11268: Introduced Profiler module with new Glue plugins and confi…

### DIFF
--- a/src/Spryker/Glue/Profiler/Plugin/EventDispatcher/ProfilerRequestEventDispatcherPlugin.php
+++ b/src/Spryker/Glue/Profiler/Plugin/EventDispatcher/ProfilerRequestEventDispatcherPlugin.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Glue\Profiler\Plugin\EventDispatcher;
+
+use Spryker\Glue\Kernel\AbstractPlugin;
+use Spryker\Service\Container\ContainerInterface;
+use Spryker\Shared\EventDispatcher\EventDispatcherInterface;
+use Spryker\Shared\EventDispatcherExtension\Dependency\Plugin\EventDispatcherPluginInterface;
+use Symfony\Component\HttpKernel\Event\KernelEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * @method \Spryker\Glue\Profiler\ProfilerFactory getFactory()
+ * @method \Spryker\Glue\Profiler\ProfilerConfig getConfig()
+ */
+class ProfilerRequestEventDispatcherPlugin extends AbstractPlugin implements EventDispatcherPluginInterface
+{
+    /**
+     * @var int
+     */
+    protected const LISTENER_PRIORITY = 50;
+
+    /**
+     * {@inheritDoc}
+     * - Adds listener for `KernelEvents::REQUEST`.
+     * - Adds listener for `KernelEvents::EXCEPTION`.
+     * - Adds listener for `KernelEvents::RESPONSE`.
+     *
+     * @api
+     *
+     * @param \Spryker\Shared\EventDispatcher\EventDispatcherInterface $eventDispatcher
+     * @param \Spryker\Service\Container\ContainerInterface $container
+     *
+     * @return \Spryker\Shared\EventDispatcher\EventDispatcherInterface
+     */
+    public function extend(EventDispatcherInterface $eventDispatcher, ContainerInterface $container): EventDispatcherInterface
+    {
+        $eventDispatcher->addListener(KernelEvents::REQUEST, [$this, 'onRequestStart'], static::LISTENER_PRIORITY);
+        $eventDispatcher->addListener(KernelEvents::EXCEPTION, [$this, 'onRequestFinish'], static::LISTENER_PRIORITY);
+        $eventDispatcher->addListener(KernelEvents::RESPONSE, [$this, 'onRequestFinish'], static::LISTENER_PRIORITY);
+
+        return $eventDispatcher;
+    }
+
+    /**
+     * @param \Symfony\Component\HttpKernel\Event\KernelEvent $event
+     *
+     * @return void
+     */
+    public function onRequestStart(KernelEvent $event): void
+    {
+        if (!$this->isProfilerEnabled()) {
+            return;
+        }
+
+        xhprof_enable(XHPROF_FLAGS_NO_BUILTINS);
+    }
+
+    /**
+     * @param \Symfony\Component\HttpKernel\Event\KernelEvent $event
+     *
+     * @return void
+     */
+    public function onRequestFinish(KernelEvent $event): void
+    {
+        if (!$this->isProfilerEnabled()) {
+            return;
+        }
+
+        if ($this->isProfilerPanelRequest($event)) {
+            return;
+        }
+
+        $xhprofData = xhprof_disable();
+
+        if (empty($xhprofData)) {
+            return;
+        }
+
+        $profilerOutputData = $this->getFactory()->createProfilerCallTraceVisualizer()->visualizeProfilerCallTrace($xhprofData);
+        $this->getFactory()->createProfilerDataStorage()->logProfilerData($profilerOutputData);
+    }
+
+    /**
+     * @return bool
+     */
+    protected function isProfilerEnabled(): bool
+    {
+        return extension_loaded('xhprof') && $this->getConfig()->isProfilerEnabled();
+    }
+
+    /**
+     * @param \Symfony\Component\HttpKernel\Event\KernelEvent $event
+     *
+     * @return bool
+     */
+    protected function isProfilerPanelRequest(KernelEvent $event): bool
+    {
+        $requestUri = $event->getRequest()->server->get('REQUEST_URI', '');
+
+        return (bool)preg_match('~^/_(?:profiler|fragment)~', $requestUri);
+    }
+}

--- a/src/Spryker/Glue/Profiler/Plugin/WebProfiler/WebProfilerProfilerDataCollectorPlugin.php
+++ b/src/Spryker/Glue/Profiler/Plugin/WebProfiler/WebProfilerProfilerDataCollectorPlugin.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Glue\Profiler\Plugin\WebProfiler;
+
+use Spryker\Glue\Kernel\AbstractPlugin;
+use Spryker\Service\Container\ContainerInterface;
+use Spryker\Shared\WebProfilerExtension\Dependency\Plugin\WebProfilerDataCollectorPluginInterface;
+use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
+
+/**
+ * @method \Spryker\Glue\Profiler\ProfilerFactory getFactory()
+ */
+class WebProfilerProfilerDataCollectorPlugin extends AbstractPlugin implements WebProfilerDataCollectorPluginInterface
+{
+    /**
+     * @var string
+     */
+    protected const DATA_COLLECTOR_NAME = 'profiler';
+
+    /**
+     * @var string
+     */
+    protected const DATA_TEMPLATE_NAME = '@Profiler/profiler';
+
+    /**
+     * {@inheritDoc}
+     *
+     * @api
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return static::DATA_COLLECTOR_NAME;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @api
+     *
+     * @return string
+     */
+    public function getTemplateName(): string
+    {
+        return static::DATA_TEMPLATE_NAME;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @api
+     *
+     * @param \Spryker\Service\Container\ContainerInterface $container
+     *
+     * @return \Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface
+     */
+    public function getDataCollector(ContainerInterface $container): DataCollectorInterface
+    {
+        return $this->getFactory()->createProfilerDataCollector();
+    }
+}

--- a/src/Spryker/Glue/Profiler/ProfilerConfig.php
+++ b/src/Spryker/Glue/Profiler/ProfilerConfig.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Glue\Profiler;
+
+use Spryker\Glue\Kernel\AbstractBundleConfig;
+use Spryker\Shared\Profiler\ProfilerConstants;
+
+class ProfilerConfig extends AbstractBundleConfig
+{
+    /**
+     * @var int
+     */
+    protected const MIN_NODE_EXECUTION_WALL_TIME_IN_MICRO_SEC = 10000;
+
+    /**
+     * @api
+     *
+     * @return bool
+     */
+    public function isProfilerEnabled(): bool
+    {
+        return $this->get(ProfilerConstants::IS_PROFILER_ENABLED, false);
+    }
+
+    /**
+     * @api
+     *
+     * @return int
+     */
+    public function getMinNodeExecutionWallTimeInMicroSeconds(): int
+    {
+        return static::MIN_NODE_EXECUTION_WALL_TIME_IN_MICRO_SEC;
+    }
+}

--- a/src/Spryker/Glue/Profiler/ProfilerFactory.php
+++ b/src/Spryker/Glue/Profiler/ProfilerFactory.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Glue\Profiler;
+
+use Spryker\Glue\Kernel\AbstractFactory;
+use Spryker\Shared\Profiler\ProfilerCallTraceVisualizer\ProfilerCallTraceVisualizer;
+use Spryker\Shared\Profiler\ProfilerCallTraceVisualizer\ProfilerCallTraceVisualizerInterface;
+use Spryker\Shared\Profiler\ProfilerData\ProfilerDataStorageInterface;
+use Spryker\Shared\Profiler\ProfilerData\ProfilerDataStorageSingleInstancePool;
+use Spryker\Shared\Profiler\ProfilerGraph\ProfilerGraphModuleFilterCondition;
+use Spryker\Shared\Profiler\ProfilerGraph\ProfilerGraphNodeStorageFactory;
+use Spryker\Shared\Profiler\ProfilerGraph\ProfilerGraphNodeStorageFactoryInterface;
+use Spryker\Shared\Profiler\ProfilerGraphDumper\ProfilerGraphDumperInterface;
+use Spryker\Shared\Profiler\ProfilerGraphDumper\SvgProfilerGraphDumper;
+use Spryker\Shared\Profiler\ProfilerGraphDumper\SvgProfilerModuleStyler;
+use Spryker\Shared\Profiler\ProfilerGraphFactory\ProfilerGraphFactoryInterface;
+use Spryker\Shared\Profiler\ProfilerGraphFactory\XhprofProfilerGraphFactory;
+use Spryker\Shared\Profiler\WebProfiler\ProfilerDataCollector;
+
+/**
+ * @method \Spryker\Glue\Profiler\ProfilerConfig getConfig()
+ */
+class ProfilerFactory extends AbstractFactory
+{
+    /**
+     * @return \Spryker\Shared\Profiler\ProfilerData\ProfilerDataStorageInterface
+     */
+    public function createProfilerDataStorage(): ProfilerDataStorageInterface
+    {
+        return (new ProfilerDataStorageSingleInstancePool())->getProfilerDataStorage();
+    }
+
+    /**
+     * @return \Spryker\Shared\Profiler\WebProfiler\ProfilerDataCollector
+     */
+    public function createProfilerDataCollector(): ProfilerDataCollector
+    {
+        return new ProfilerDataCollector($this->createProfilerDataStorage());
+    }
+
+    /**
+     * @return \Spryker\Shared\Profiler\ProfilerCallTraceVisualizer\ProfilerCallTraceVisualizerInterface
+     */
+    public function createProfilerCallTraceVisualizer(): ProfilerCallTraceVisualizerInterface
+    {
+        return new ProfilerCallTraceVisualizer(
+            $this->createProfilerGraphFactory(),
+            $this->getProfilerGraphFilterConditions(),
+            $this->createProfilerGraphDumper(),
+        );
+    }
+
+    /**
+     * @return \Spryker\Shared\Profiler\ProfilerGraphDumper\ProfilerGraphDumperInterface
+     */
+    public function createProfilerGraphDumper(): ProfilerGraphDumperInterface
+    {
+        return new SvgProfilerGraphDumper($this->getSvgProfilerModuleStylers());
+    }
+
+    /**
+     * @return array<\Spryker\Shared\Profiler\ProfilerGraphDumper\SvgProfilerModuleStyler>
+     */
+    public function getSvgProfilerModuleStylers(): array
+    {
+        return [
+            $this->createSvgProfilerModuleStyler(),
+        ];
+    }
+
+    /**
+     * @return \Spryker\Shared\Profiler\ProfilerGraphDumper\SvgProfilerModuleStyler
+     */
+    public function createSvgProfilerModuleStyler(): SvgProfilerModuleStyler
+    {
+        return new SvgProfilerModuleStyler();
+    }
+
+    /**
+     * @return array<\Spryker\Shared\Profiler\ProfilerGraph\ProfilerGraphFilterConditionInterface>
+     */
+    public function getProfilerGraphFilterConditions(): array
+    {
+        return [
+            $this->createProfilerGraphFilterCondition(),
+        ];
+    }
+
+    /**
+     * @return \Spryker\Shared\Profiler\ProfilerGraph\ProfilerGraphModuleFilterCondition
+     */
+    public function createProfilerGraphFilterCondition(): ProfilerGraphModuleFilterCondition
+    {
+        return new ProfilerGraphModuleFilterCondition();
+    }
+
+    /**
+     * @return \Spryker\Shared\Profiler\ProfilerGraphFactory\ProfilerGraphFactoryInterface
+     */
+    public function createProfilerGraphFactory(): ProfilerGraphFactoryInterface
+    {
+        return new XhprofProfilerGraphFactory(
+            $this->createProfilerGraphNodeStorageFactory(),
+            $this->getConfig()->getMinNodeExecutionWallTimeInMicroSeconds(),
+        );
+    }
+
+    /**
+     * @return \Spryker\Shared\Profiler\ProfilerGraph\ProfilerGraphNodeStorageFactoryInterface
+     */
+    public function createProfilerGraphNodeStorageFactory(): ProfilerGraphNodeStorageFactoryInterface
+    {
+        return new ProfilerGraphNodeStorageFactory();
+    }
+}

--- a/src/Spryker/Glue/Profiler/Theme/default/profiler-script.html.twig
+++ b/src/Spryker/Glue/Profiler/Theme/default/profiler-script.html.twig
@@ -1,0 +1,30 @@
+<script>
+    class Profiler {
+        downloadLink = document.querySelector('.js-profiler-svg-graph-button');
+        svgContainer = document.querySelector('.js-profiler-svg-graph');
+
+        init() {
+            this.setDownloadUrl();
+            this.setScrollPosition();
+        }
+
+        setDownloadUrl() {
+            const svg = this.svgContainer.innerHTML;
+            const blob = new Blob([svg.toString()]);
+
+            this.downloadLink.download = 'profiler-call-graph.svg';
+            this.downloadLink.href = window.URL.createObjectURL(blob);
+        }
+
+        setScrollPosition() {
+            const wrapperWidth = this.svgContainer.offsetWidth;
+            const svgRootNodeOffset = this.svgContainer.querySelector('svg #node1 text').getBBox().x;
+            const ptToPxRatio = 1.33;
+
+            this.svgContainer.scroll(svgRootNodeOffset * ptToPxRatio - wrapperWidth/2, 0);
+        }
+    }
+
+    const profiler = new Profiler();
+    profiler.init();
+</script>

--- a/src/Spryker/Glue/Profiler/Theme/default/profiler.html.twig
+++ b/src/Spryker/Glue/Profiler/Theme/default/profiler.html.twig
@@ -1,0 +1,44 @@
+{% extends '@WebProfiler/Profiler/layout.html.twig' %}
+
+{% block toolbar %}
+    {% set icon %}
+        {% block profilerIcon %}
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="#AAA" d="M2.3 6l9-4.6a1.5 1.5 0 0 1 1.4 0l9 4.7a1.5 1.5 0 0 1 0 2.6l-9 4.7a1.5 1.5 0 0 1-1.4 0l-9-4.7a1.5 1.5 0 0 1 0-2.6zm18.3 5L12 15.4 3.4 11a1.4 1.4 0 0 0-1.2 2.4l9.2 4.8a1.4 1.4 0 0 0 1.2 0l9.2-4.8a1.4 1.4 0 0 0-1.3-2.4zm0 4.5L12 19.9l-8.6-4.4a1.4 1.4 0 0 0-1.2 2.4l9.2 4.7a1.4 1.4 0 0 0 1.2 0l9.2-4.7a1.4 1.4 0 0 0-1.3-2.5z"/></svg>
+        {% endblock %}
+        <span class="sf-toolbar-value">Profiler</span>
+    {% endset %}
+
+    {% if collector.profilerData.isXhprofExtensionEnabled %}
+        {% set text %}
+            <div class="sf-toolbar-info-piece">
+                {% for key, value in collector.profilerData.stats %}
+                    <b>{{ key }}</b>
+                    <span>{{ value }}</span>
+                {% endfor %}
+            </div>
+        {% endset %}
+    {% endif %}
+
+    {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: profiler_url, name: 'profiler'}) }}
+{% endblock %}
+
+{% block menu %}
+    <span class="label">
+        <span class="icon">
+            {{ block('profilerIcon') }}
+        </span>
+        <strong>Profiler</strong>
+    </span>
+{% endblock %}
+
+{% block panel %}
+    {% if collector.profilerData.isXhprofExtensionEnabled %}
+        <a href="#" class="btn js-profiler-svg-graph-button">Download Trace Graph</a>
+        <div class="js-profiler-svg-graph" style="overflow: auto; margin-top: 10px">
+            {{ collector.profilerData.content | raw }}
+        </div>
+        {{ include('@Profiler/profiler-script.html.twig') }}
+    {% else %}
+        <p>To view modules call trace please enable xhprof extension. See <a href="https://docs.spryker.com/docs/scos/dev/technical-enhancement-integration-guides/Integrate-profiler-module.html#prerequisites">profiler module docs.</a></p>
+    {% endif %}
+{% endblock %}


### PR DESCRIPTION
- Developer(s): @vitaliiivanovspryker

- Ticket: https://spryker.atlassian.net/browse/FRW-11268

- Release Group: https://release.spryker.com/release-groups/view/6236

- PR Overview: https://release.spryker.com/core/FRW-11268 [Replace with actual PR overview link]

- Suite PR: https://github.com/spryker/suite/pull/150

- merge: squash

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Profiler       |        patch               |                       |

-----------------------------------------

#### Module Profiler

##### Change log

Improvements

- Added `ProfilerRequestEventDispatcherPlugin` to handle events in Glue applications.
- Implemented `WebProfilerProfilerDataCollectorPlugin` to collect profiler data for Glue applications.
- Fixed `ProfilerRequestEventDispatcherPlugin` for Zed application excluding profile panel uri.
