### PR TITLE
FRW-11269 Fix profiler module for Gateway profiles

### DIFF
--- a/src/Spryker/Zed/Profiler/Communication/Plugin/EventDispatcher/ProfilerRequestEventDispatcherPlugin.php
+++ b/src/Spryker/Zed/Profiler/Communication/Plugin/EventDispatcher/ProfilerRequestEventDispatcherPlugin.php
@@ -62,6 +62,10 @@ class ProfilerRequestEventDispatcherPlugin extends AbstractPlugin implements Eve
             return;
         }
 
+        if ($this->isProfilerPanelRequest($event)) {
+            return;
+        }
+
         xhprof_enable(XHPROF_FLAGS_NO_BUILTINS);
     }
 
@@ -80,11 +84,11 @@ class ProfilerRequestEventDispatcherPlugin extends AbstractPlugin implements Eve
             return;
         }
 
-        $xhprofData = xhprof_disable();
-
-        if (!is_array($xhprofData)) {
+        if ($this->isProfilerPanelRequest($event)) {
             return;
         }
+
+        $xhprofData = xhprof_disable();
 
         $profilerOutputData = $this->getFactory()->createProfilerCallTraceVisualizer()->visualizeProfilerCallTrace($xhprofData);
         $this->getFactory()->createProfilerDataStorage()->logProfilerData($profilerOutputData);
@@ -96,5 +100,17 @@ class ProfilerRequestEventDispatcherPlugin extends AbstractPlugin implements Eve
     protected function isProfilerEnabled(): bool
     {
         return extension_loaded('xhprof') && $this->getConfig()->isProfilerEnabled();
+    }
+
+    /**
+     * @param \Symfony\Component\HttpKernel\Event\KernelEvent $event
+     *
+     * @return bool
+     */
+    protected function isProfilerPanelRequest(KernelEvent $event): bool
+    {
+        $requestUri = $event->getRequest()->server->get('REQUEST_URI', '');
+
+        return (bool)preg_match('~^/_(?:profiler|fragment)~', $requestUri);
     }
 }


### PR DESCRIPTION
- Developer(s): @vitaliiivanovspryker

- Ticket: https://spryker.atlassian.net/browse/FRW-11269

- Release Group: https://release.spryker.com/release-groups/view/6242

- PR Overview: https://release.spryker.com/core/FRW-11269 [Replace with actual PR overview link]

- merge: squash

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Profiler       |        patch               |                       |

-----------------------------------------

#### Module Profiler

Fixes

- Fixed `ProfilerRequestEventDispatcherPlugin` for Zed application, excluding profile panel URI.